### PR TITLE
fix: rename vitepress-docs to airnode-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# API3 Technical Documentation
+# API3 Airnode Technical Documentation
 
-The technical documentation is maintained by the core technical team. Please
-feel free to create [issues](https://github.com/api3dao/vitepress-docs/issues)
-for discussions, proposals, additions, and changes in the repo `vitepress-docs`.
+The Airnode technical documentation is maintained by the core technical team.
+Please feel free to create
+[issues](https://github.com/api3dao/airnode-docs/issues) for discussions,
+proposals, additions, and changes in the repo `airnode-docs`.
 
 ## VitePress
 
@@ -10,16 +11,16 @@ The technical documentation has moved from
 [VuePress](https://vuepress.vuejs.org) to
 [VitePress](https://vitepress.vuejs.org).
 
-- `vitepress-docs`: uses VitePress
-- `api3-docs`: uses VuePress
+- `airnode-docs`: uses VitePress
+- `old-api3-docs`: uses VuePress
 
 ## Firebase
 
-Firebase is used to host the `vitepress-docs` technical documentation.
+Firebase is used to host the `airnode-docs` technical documentation.
 
 ### Production
 
-- DNS: https://docs.api3.org
+- DNS: https://airnode-docs.api3.org
 - Hosted with Firebase: https://vitepress-docs.web.app
 
 ### Previews
@@ -42,6 +43,6 @@ https://old-docs.api3.org and is still hosted using `gh-pages`.
 
 ## /dev/ docset
 
-Use https://docs.api3.org/dev/ to learn more about how the `vitepress-docs`
+Use https://docs.api3.org/dev/ to learn more about how the `airnode-docs`
 documentation is managed. For the legacy documentation use
 https://old-docs.api3.org/dev/.

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -49,7 +49,7 @@ export default {
     },
     siteTitle: 'Documentation',
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/api3dao/vitepress-docs' },
+      { icon: 'github', link: 'https://github.com/api3dao/airnode-docs' },
       {
         icon: 'discord',
         link: 'https://discord.com/channels/758003776174030948/765618225144266793',

--- a/docs/_components/search/SearchBtn.vue
+++ b/docs/_components/search/SearchBtn.vue
@@ -193,16 +193,16 @@ export default {
         reg = await axios.get(`/indexes/${name}/reg.json`);
       } else {
         cfg = await axios.get(
-          `https://raw.githubusercontent.com/api3dao/vitepress-docs/main/docs/public/indexes/${name}/cfg.json`
+          `https://raw.githubusercontent.com/api3dao/airnode-docs/main/docs/public/indexes/${name}/cfg.json`
         );
         ctx = await axios.get(
-          `https://raw.githubusercontent.com/api3dao/vitepress-docs/main/docs/public/indexes/${name}/ctx.json`
+          `https://raw.githubusercontent.com/api3dao/airnode-docs/main/docs/public/indexes/${name}/ctx.json`
         );
         map = await axios.get(
-          `https://raw.githubusercontent.com/api3dao/vitepress-docs/main/docs/public/indexes/${name}/map.json`
+          `https://raw.githubusercontent.com/api3dao/airnode-docs/main/docs/public/indexes/${name}/map.json`
         );
         reg = await axios.get(
-          `https://raw.githubusercontent.com/api3dao/vitepress-docs/main/docs/public/indexes/${name}/reg.json`
+          `https://raw.githubusercontent.com/api3dao/airnode-docs/main/docs/public/indexes/${name}/reg.json`
         );
       }
 

--- a/docs/dev/axios-scripts.md
+++ b/docs/dev/axios-scripts.md
@@ -13,12 +13,12 @@ tags:
 # {{$frontmatter.title}}
 
 The script
-[axiosBuildScripts.js](https://github.com/api3dao/vitepress-docs/blob/main/libs/axiosBuildScripts.js)
+[axiosBuildScripts.js](https://github.com/api3dao/airnode-docs/blob/main/libs/axiosBuildScripts.js)
 is used to generated local data files. These files are rendered by certain
 markdown pages as a data source. For example see these markdown files:
 
-- [/reference/dapis/chains/chains-list.md](https://raw.githubusercontent.com/api3dao/vitepress-docs/main/docs/reference/dapis/chains/chains-list.md)
-- [/reference/airnode/latest/index.md](https://raw.githubusercontent.com/api3dao/vitepress-docs/main/docs/reference/airnode/latest/index.md)
+- [/reference/dapis/chains/chains-list.md](https://raw.githubusercontent.com/api3dao/airnode-docs/main/docs/reference/dapis/chains/chains-list.md)
+- [/reference/airnode/latest/index.md](https://raw.githubusercontent.com/api3dao/airnode-docs/main/docs/reference/airnode/latest/index.md)
 
 The local data files provide for a better page load experience rather than
 real-time data access from the monorepo. More importantly, the local data files

--- a/docs/dev/containers.md
+++ b/docs/dev/containers.md
@@ -13,7 +13,7 @@ tags:
 # {{$frontmatter.title}}
 
 VitePress provides several containers. The following examples explain how they
-should be used in `vitepress-docs`.
+should be used in `airnode-docs`.
 
 ::: info
 

--- a/docs/dev/firebase.md
+++ b/docs/dev/firebase.md
@@ -14,10 +14,10 @@ tags:
 
 All production and PR preview deployments are published on Firebase hosting and
 are built automatically using GitHub
-[workflows](https://github.com/api3dao/vitepress-docs/tree/main/.github/workflows)
-stored in the `vitepress-docs` repo.
+[workflows](https://github.com/api3dao/airnode-docs/tree/main/.github/workflows)
+stored in the `airnode-docs` repo.
 
-- Production: https://vitepress-docs.web.app (and https://docs.api3.org)
+- Production: https://vitepress-docs.web.app (and https://airnode-docs.api3.org)
 
 ## Repo Branches
 

--- a/docs/dev/flexsearch.md
+++ b/docs/dev/flexsearch.md
@@ -14,7 +14,7 @@ tags:
 
 [FlexSearch](https://www.npmjs.com/package/flexsearch) is used to support
 searching in the docs. The script
-[/libs/flexBuildIndexes.js](https://github.com/api3dao/vitepress-docs/blob/main/libs/flexBuildIndexes.js)
+[/libs/flexBuildIndexes.js](https://github.com/api3dao/airnode-docs/blob/main/libs/flexBuildIndexes.js)
 will index all HTML files in the `/dist` folder for the following directories:
 
 - `/dist/explore/`
@@ -56,11 +56,11 @@ their content is generated at runtime in the browser. For example: a component
 uses Axios to pull data from an API operation.
 
 To overcome this short fall, the script
-[/axiosBuildScripts.js](https://github.com/api3dao/vitepress-docs/blob/main/libs/axiosBuildScripts.js)
+[/axiosBuildScripts.js](https://github.com/api3dao/airnode-docs/blob/main/libs/axiosBuildScripts.js)
 gathers on-line data into local data files for markdown pages to use. This
 allows for proper rendering of HTML at build time. A example of a markdown file
 that uses a locally generated data file is
-[chains-list.md](https://raw.githubusercontent.com/api3dao/vitepress-docs/main/docs/reference/dapis/chains/chains-list.md).
+[chains-list.md](https://raw.githubusercontent.com/api3dao/airnode-docs/main/docs/reference/dapis/chains/chains-list.md).
 
 ## Creating/updating the index files
 

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -20,7 +20,7 @@ Mac users (Apple silicon) should see the page
 
 It is best to use nodejs `v20` which gives the best performance and is the
 engine described in the
-[<span style="color:rgb(16, 185, 129);">package.json</span>](https://github.com/api3dao/vitepress-docs/blob/main/package.json)
+[<span style="color:rgb(16, 185, 129);">package.json</span>](https://github.com/api3dao/airnode-docs/blob/main/package.json)
 file.
 
 :::
@@ -30,8 +30,8 @@ file.
 Clone the remote repo and install it packages.
 
 ```sh
-git clone git@github.com:api3dao/vitepress-docs.git
-cd vitepress-docs
+git clone git@github.com:api3dao/airnode-docs.git
+cd airnode-docs
 pnpm install
 ```
 

--- a/docs/dev/rosetta.md
+++ b/docs/dev/rosetta.md
@@ -25,13 +25,13 @@ using your CLI with Rosetta deactivated.
 
 It is best to use nodejs `v20` which gives the best performance and is the
 engine described in the
-[package.json](https://github.com/api3dao/vitepress-docs/blob/main/package.json)
+[package.json](https://github.com/api3dao/airnode-docs/blob/main/package.json)
 file.
 
 :::
 
 ```sh
-failed to load config from /Users/warren/DEV/vitepress-docs/docs/.vitepress/config.js
+failed to load config from /Users/warren/DEV/airnode-docs/docs/.vitepress/config.js
 build error:
  Error:
 You installed esbuild for another platform than the one you're currently using.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -19,7 +19,7 @@ tags:
 Each guide is a complete standalone step-by-step introduction to Airnode. For
 Airnode the guides work with the latest version of Airnode. If you have an idea
 for a guide that you wish was here, please create a
-[GitHub issue](https://github.com/api3dao/vitepress-docs). This will help us
+[GitHub issue](https://github.com/api3dao/airnode-docs). This will help us
 create a full and comprehensive list.
 
 <FlexEndTag/>

--- a/firebase-deploy.sh
+++ b/firebase-deploy.sh
@@ -20,7 +20,7 @@ cd docs/.vitepress/dist
 # echo 'www.example.com' > CNAME
 
 # Use this section if you want to push to a depoyment branch.
-# api3dao/vitepress-docs uses the main branch as default.
+# api3dao/airnode-docs uses the main branch as default.
 # git init must start with a main branch so firebase-pages will
 # "hang" off of it.
 # git init --initial-branch=main
@@ -32,7 +32,7 @@ cd docs/.vitepress/dist
 
 # If you are deploying to https://<USERNAME>.github.io/<REPO>
 # NEVER push to main, use main:firebase-pages.
-# git push -f git@github.com:wkande/vitepress-docs.git main:firebase-pages
+# git push -f git@github.com:wkande/airnode-docs.git main:firebase-pages
 
 cd -
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vitepress-docs",
+  "name": "airnode-docs",
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
Except in regards to firebase and the firebase-hosted URL